### PR TITLE
fix: add and delete sections without page reload

### DIFF
--- a/src/components/proposal/Form.tsx
+++ b/src/components/proposal/Form.tsx
@@ -3,22 +3,15 @@
 import Header from "./Header";
 import InfoSection from "./InfoSection";
 import GPTGeneratedSection from "./GPTGeneratedSection";
-import { useState } from "react";
 import DeleteButton from "./buttons/DeleteButton";
 import Row from "./Row";
-import AddButton from "./buttons/AddButton";
 
-export default function Form() {
-  const [addSection, setAddSection] = useState(1);
+interface FormProps {
+  onClickDelete: () => void;
+  sectionsCount: number;
+}
 
-  const handleAddSection = () => {
-    setAddSection((prev) => prev + 1);
-  };
-
-  const handleRemoveSection = () => {
-    setAddSection((prev) => prev - 1);
-  };
-
+export default function Form({ onClickDelete, sectionsCount }: FormProps) {
   return (
     <form className="flex flex-col gap-8">
       <Row>
@@ -27,18 +20,12 @@ export default function Form() {
       <Row>
         <InfoSection className="col-start-2 col-end-3" />
       </Row>
-      {Array.from({ length: addSection }).map((i, index) => (
+      {Array.from({ length: sectionsCount }).map((i, index) => (
         <Row key={index}>
           <GPTGeneratedSection className="col-start-2 col-end-3" />
-          <DeleteButton onClick={handleRemoveSection} />
+          <DeleteButton onClick={onClickDelete} />
         </Row>
       ))}
-      <Row>
-        <AddButton
-          onClick={handleAddSection}
-          className="col-start-3 col-end-4"
-        />
-      </Row>
     </form>
   );
 }

--- a/src/components/proposal/Proposal.tsx
+++ b/src/components/proposal/Proposal.tsx
@@ -1,9 +1,30 @@
+"use client";
+
 import Form from "./Form";
+import Row from "./Row";
+import AddButton from "./buttons/AddButton";
+import { useState } from "react";
 
 export default function Proposal() {
+  const [addSection, setAddSection] = useState(1);
+
+  const handleAddSection = () => {
+    setAddSection((prev) => prev + 1);
+  };
+
+  const handleRemoveSection = () => {
+    setAddSection((prev) => prev - 1);
+  };
+
   return (
-    <>
-      <Form />
-    </>
+    <div className="flex flex-col">
+      <Form onClickDelete={handleRemoveSection} sectionsCount={addSection} />
+      <Row>
+        <AddButton
+          onClick={handleAddSection}
+          className="col-start-3 col-end-4"
+        />
+      </Row>
+    </div>
   );
 }

--- a/src/components/proposal/buttons/DeleteButton.tsx
+++ b/src/components/proposal/buttons/DeleteButton.tsx
@@ -10,6 +10,7 @@ export default function DeleteButton({ onClick }: DeleteButtonProps) {
     <div className="relative h-full w-full px-2">
       <div className="h-full w-px bg-level-3  hidden group-hover/row:flex" />
       <Button
+        type="button"
         variant="ghost"
         size="icon"
         className={`absolute items-center justify-center top-1/2 right-0 group/button -translate-y-1/2 hover:!bg-red-400 hidden group-hover/row:flex`}


### PR DESCRIPTION
**Issue:**
The default submit behavior of the <button> causes a page reload when adding/deleting sections. A quick fix is to change it to type="button", but that ties the interactive logic to the form and complicates PDF exports.

**Solution:**
Lift the state and controls (add button) to a parent component. This keeps the form purely presentational and ensures interactive elements don't appear in the PDF.

**Benefits:**
- Clear separation of concerns
- Easier future enhancements
- Simplified PDF export with no extra CSS workarounds

**Testing:**
Verified that section additions and deletions work as expected without causing page reloads.